### PR TITLE
Fixed #34 - Remove maven-aether-provider / maven-compat

### DIFF
--- a/mvn-golang-wrapper/pom.xml
+++ b/mvn-golang-wrapper/pom.xml
@@ -52,22 +52,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>3.0</version>
-      <scope>test</scope>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-artifact-transfer</artifactId>
+      <version>0.9.1</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>${mvn.version}</version>
-      <scope>provided</scope>
-    </dependency>
+    <!--
+      ! Maven Compat is only needed for maven-plugin-testing-harness.  
+     -->
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <version>${mvn.version}</version>
-      <scope>provided</scope>
+      <version>3.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>


### PR DESCRIPTION
Added maven-artifact-transfer to make this more
compatible with different Maven versions.
- Get rid of maven-aether-provider, maven-artifact
  and maven-compat for runtime only as test
  scope dependency left for maven-plugin-testing-harness.
- Removed localRepository cause it was defined as
  required and readonly