### PR TITLE
Further Fix for Issue #48

### DIFF
--- a/mvn-golang-wrapper/src/main/filtered-resources/META-INF/plexus/components.xml
+++ b/mvn-golang-wrapper/src/main/filtered-resources/META-INF/plexus/components.xml
@@ -17,8 +17,8 @@
                             <process-sources>com.igormaznitsa:mvn-golang-wrapper:${project.version}:fmt</process-sources>
                             <test>com.igormaznitsa:mvn-golang-wrapper:${project.version}:test</test>
                             <package>com.igormaznitsa:mvn-golang-wrapper:${project.version}:build</package>
-                            <install>com.igormaznitsa:mvn-golang-wrapper:${project.version}:mvninstall</install>
-                            <deploy>com.igormaznitsa:mvn-golang-wrapper:${project.version}:install</deploy>
+                            <install>com.igormaznitsa:mvn-golang-wrapper:${project.version}:mvninstall,org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>com.igormaznitsa:mvn-golang-wrapper:${project.version}:install,org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
                         </phases>
                     </lifecycle>
                 </lifecycles>

--- a/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangMvnInstallMojo.java
+++ b/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangMvnInstallMojo.java
@@ -100,25 +100,7 @@ public class GolangMvnInstallMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
       try {
         final File archive = compressProjectFiles();
-        try {
-          final ProjectBuildingRequest pbr = this.session.getProjectBuildingRequest();
-          this.project.getArtifact().setFile(archive);
-
-          final List<Artifact> artifactsToInstall = new ArrayList<Artifact>();
-
-          artifactsToInstall.add(this.project.getArtifact());
-          if (this.isInstallAttached()) {
-            artifactsToInstall.addAll(this.project.getAttachedArtifacts());
-          }
-
-          this.installer.install(pbr, artifactsToInstall);
-        } finally {
-          // Usually created archives etc. will be created in target directory
-          // and will not be deleted by the plugin itself. Usually by `mvn clean ..`..
-          FileUtils.deleteQuietly(archive);
-        }
-      } catch (ArtifactInstallerException ex) {
-        throw new MojoFailureException("Can't install the artifact!", ex);
+        this.project.getArtifact().setFile(archive);
       } catch (IOException ex) {
         throw new MojoExecutionException("Detected unexpected IOException, check the log!", ex);
       }


### PR DESCRIPTION
This is an attempt to show what I was trying to articulate in my earlier comments. Rely on the mature apache plugins for pushing project artifacts to the local repo or remote artifact repos with the maven-install-plugin and maven-deploy-plugin. But, still rely on the mojos within this project to perform the golang actions, and also create the `.mvn-golang` that will be the primary artifact for the project along with the project pom.

**Changes**:
* Still rely on the custom mojos to perform the custom golang actions for the project.
* Rely on the apache maven-install-plugin to perform the actions to install project artifacts to the local repo.
* Rely on the apache maven-deploy-plugin to perform the deployment actions to place the project artifacts in a artifact repository.