### PR TITLE
multiple package fix

### DIFF
--- a/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangBuildMojo.java
+++ b/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangBuildMojo.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.igormaznitsa.meta.common.utils.Assertions.assertNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The Mojo wraps the 'build' command.
@@ -198,9 +199,11 @@ public class GolangBuildMojo extends AbstractGoPackageAndDependencyAwareMojo {
       }
       flags.add(buffer.toString());
     }
-
-    flags.add("-o");
-    flags.add(getResultFile().getAbsolutePath());
+    // multiple packages fix - go build: cannot use -o with multiple packages
+    if (requireNonNull(getPackages()).length < 2) {
+      flags.add("-o");
+      flags.add(getResultFile().getAbsolutePath());
+    }
 
     return flags.toArray(new String[flags.size()]);
   }

--- a/mvn-golang-wrapper/src/test/java/com/igormaznitsa/mvngolang/GolangMojoCfgTest.java
+++ b/mvn-golang-wrapper/src/test/java/com/igormaznitsa/mvngolang/GolangMojoCfgTest.java
@@ -28,6 +28,12 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static java.util.Arrays.asList;
+import static java.util.Arrays.copyOfRange;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 
 public class GolangMojoCfgTest extends AbstractMojoTestCase {
@@ -401,6 +407,15 @@ public class GolangMojoCfgTest extends AbstractMojoTestCase {
     assertEquals("somevalue", buildMojo.getEnv().get("somekey"));
     assertEquals("bin/misc", buildMojo.getExecSubpath());
     assertEquals("gomobile", buildMojo.getExec());
+    // multiple package test
+    assertEquals(2, buildMojo.getPackages().length);
+    assertThat(asList(buildMojo.getCommandFlags()), not(hasItem("-o")));
+    assertThat(asList(buildMojo.getCommandFlags()), not(hasItem(endsWith("targetName"))));
+    // single package test
+    buildMojo.setPackages(copyOfRange(buildMojo.getPackages(), 0, 1));
+    assertEquals(1, buildMojo.getPackages().length);
+    assertThat(asList(buildMojo.getCommandFlags()), hasItem("-o"));
+    assertThat(asList(buildMojo.getCommandFlags()), hasItem(endsWith("targetName")));
   }
 
 }


### PR DESCRIPTION
Multiple packages results in error `go build: cannot use -o with multiple packages`

```
    <build>
        <plugins>
            <plugin>
                <groupId>com.igormaznitsa</groupId>
                <artifactId>mvn-golang-wrapper</artifactId>
                <configuration>
                    <packages>
                        <package>one_pack</package>
                        <package>two_pack</package>
                    </packages>
```