### PR TITLE
Create temporary directory to pack project under target/

### DIFF
--- a/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangMvnInstallMojo.java
+++ b/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangMvnInstallMojo.java
@@ -166,7 +166,7 @@ public class GolangMvnInstallMojo extends AbstractGoDependencyAwareMojo {
       throw new IOException("Can't delete file : " + resultZip);
     }
 
-    final File folderToPack = new File(".tmp_pack_folder_" +
+    final File folderToPack = new File(buildFolder, ".tmp_pack_folder_" +
             Long.toHexString(System.currentTimeMillis()).toUpperCase(Locale.ENGLISH));
     if (folderToPack.isDirectory()) {
       FileUtils.deleteDirectory(folderToPack);


### PR DESCRIPTION
The temporary directory used to pack the project is created under the
current directory. For a multimodules project, if modules are built
concurrently, it means there's an opportunity for 2 modules tries to
create the same temporary directory with one of them failing.

To prevent this issue, create the temporary directory under the build
output directory (which also make cleaning easier if process crashes).

Fixes #88 