### PR TITLE
Removed 'requiresDependencyResolution' for Clean Mojo

### DIFF
--- a/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangCleanMojo.java
+++ b/mvn-golang-wrapper/src/main/java/com/igormaznitsa/mvngolang/GolangCleanMojo.java
@@ -32,7 +32,7 @@ import org.codehaus.plexus.util.FileUtils;
 /**
  * The Mojo wraps the 'clean' command.
  */
-@Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN, threadSafe = true)
 public class GolangCleanMojo extends AbstractGoPackageAndDependencyAwareMojo {
 
   /**


### PR DESCRIPTION
When using mvn-golang-wrapper, mvn clean fails when there are dependencies on other modules in a multi-module project. This is happening even in the examples in this repo.

The actual issue is due to the fact that dependent artifacts are not available.

Root cause  `com.igormaznitsa.mvngolang.GolangCleanMojo` declares `requiresDependencyResolution = ResolutionScope.COMPILE`.

fixes #90 